### PR TITLE
Correcting 'or' FilterExpression

### DIFF
--- a/Sources/ODataSwift/Filter.swift
+++ b/Sources/ODataSwift/Filter.swift
@@ -273,7 +273,7 @@ public class FilterExp: QueryConvertible {
     e.g $filter=Age lt 65 or (Name eq 'martin')
     */
     public func or(_ expressions: [FilterExp])->Self {
-        self.conjection = .and
+        self.conjection = .or
         self.expressions = expressions
         return self
     }


### PR DESCRIPTION
Probably a Copy&Paste mistake:
The 'or' filter expression for combining multiple expressions was using a 'and' conjection.