### PR TITLE
Add support for orderBy in expand

### DIFF
--- a/Examples/Example-iOS/ODataSwiftExample/ODataSwiftExample/Base.lproj/Main.storyboard
+++ b/Examples/Example-iOS/ODataSwiftExample/ODataSwiftExample/Base.lproj/Main.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,9 +18,9 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JhM-PI-VDO">
-                                <rect key="frame" x="20" y="44" width="374" height="150"/>
+                                <rect key="frame" x="20" y="48" width="374" height="150"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Ph-Eo-SlW">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Ph-Eo-SlW">
                                         <rect key="frame" x="6" y="8" width="51" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$select"/>
@@ -26,7 +28,7 @@
                                             <action selector="selectDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="J2M-wa-TvK"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZGp-f8-TvU">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZGp-f8-TvU">
                                         <rect key="frame" x="90" y="8" width="41" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$filter"/>
@@ -34,7 +36,7 @@
                                             <action selector="filterDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6Zn-RR-f9g"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E4w-7Y-nuG">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E4w-7Y-nuG">
                                         <rect key="frame" x="164" y="8" width="60" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$expand"/>
@@ -42,7 +44,7 @@
                                             <action selector="expandDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="z1H-Ke-QCg"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vxW-SB-R12">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vxW-SB-R12">
                                         <rect key="frame" x="267" y="8" width="63" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$orderby"/>
@@ -51,7 +53,7 @@
                                             <action selector="orderDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9YX-eT-J2B"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p7k-eV-UYh">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p7k-eV-UYh">
                                         <rect key="frame" x="6" y="46" width="33" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$top"/>
@@ -59,7 +61,7 @@
                                             <action selector="topDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6Fy-c8-yjD"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wc4-RY-NHO">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wc4-RY-NHO">
                                         <rect key="frame" x="62" y="46" width="38" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$skip"/>
@@ -67,7 +69,7 @@
                                             <action selector="skipDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zT3-vO-bUh"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytg-dN-SsW">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ytg-dN-SsW">
                                         <rect key="frame" x="125" y="46" width="49" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$count"/>
@@ -75,7 +77,7 @@
                                             <action selector="countDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pba-NS-Dmb"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FrE-OL-80R">
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FrE-OL-80R">
                                         <rect key="frame" x="192" y="46" width="56" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="$search"/>
@@ -83,16 +85,26 @@
                                             <action selector="searchDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MwA-9M-yPV"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nIb-IG-gUX">
-                                        <rect key="frame" x="8" y="84" width="68" height="30"/>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nIb-IG-gUX">
+                                        <rect key="frame" x="7" y="84" width="68" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Functions"/>
                                         <connections>
                                             <action selector="funcDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sxD-BL-tnj"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xQC-0w-aF2">
+                                        <rect key="frame" x="104" y="83" width="166" height="32"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="$orderWithinExpand"/>
+                                        <connections>
+                                            <action selector="orderWithinExpandDidPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="w4y-l7-hOv"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="150" id="Nhv-3H-WDl"/>
                                 </constraints>
@@ -104,7 +116,8 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="9HJ-Pe-axZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="J41-jj-qvr"/>
                             <constraint firstItem="JhM-PI-VDO" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="JQk-6e-otW"/>
@@ -113,7 +126,6 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="9HJ-Pe-axZ" secondAttribute="trailing" constant="20" id="fMB-4c-2al"/>
                             <constraint firstItem="JhM-PI-VDO" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="nhS-cH-lBk"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>
                         <outlet property="labelGenQuery" destination="9HJ-Pe-axZ" id="xR9-2t-372"/>
@@ -124,4 +136,9 @@
             <point key="canvasLocation" x="140.57971014492756" y="107.8125"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Examples/Example-iOS/ODataSwiftExample/ODataSwiftExample/ViewController.swift
+++ b/Examples/Example-iOS/ODataSwiftExample/ODataSwiftExample/ViewController.swift
@@ -31,7 +31,14 @@ class ViewController: UIViewController {
         str += "\n" + ODataQueryBuilder().entity("People").filter(FilterExp("username").contains().value("7")).build()
         labelGenQuery.text = str
     }
-    
+
+    @IBAction func orderWithinExpandDidPressed(_ sender: Any) {
+        let order = Order("EndsAt", orderType: .desc)
+        let expand = Expand("Trips").order(order).selects(["FirstName", "LastName"])
+        let str = ODataQueryBuilder().entity("People").expand(expand).build()
+        labelGenQuery.text = str
+    }
+
     @IBAction func expandDidPressed(_ sender: Any) {
         let filter = FilterExp("FirstName").eq().value("Scott").and([FilterExp("FirstName").eq().value("Scott")])
         let expand = Expand("Trips").filter(filter)

--- a/Sources/ODataSwift/Expand.swift
+++ b/Sources/ODataSwift/Expand.swift
@@ -33,6 +33,9 @@ public class Expand: QueryConvertible {
     
     /// Nested Expand
     private var expand: Expand?
+
+    /// Order block within expand
+    private var order: Order?
     
     /**
      Initializes new Expand with provided navigational property or properties
@@ -93,6 +96,16 @@ public class Expand: QueryConvertible {
     }
     
     /**
+    Append new order
+
+     - Parameter order: $order property name of Order data type
+    */
+    public func order(_ order: Order) -> Self {
+        self.order = order
+        return self
+    }
+  
+    /**
     Append nested expand
      
      ~~~
@@ -110,7 +123,12 @@ public class Expand: QueryConvertible {
         var temp = "";
         temp += properties.joined(separator: ",")
         var part = "";
+        if let order = self.order {
+            part += QueryOption.order.queryText
+            part += order.queryText
+        }
         if(selects.count > 0) {
+            requestPart(part: &part)
             part += QueryOption.select.queryText
             part += selects.joined(separator: ",")
         }


### PR DESCRIPTION
**Description or summary of the feature** 

Expand doesn't support a nested order. The purpose of this PR is to add the missing functionality to the expand class so that nested order is supported. 

**Screenshots**

![OrderBySupport](https://user-images.githubusercontent.com/91461845/219078744-895a6a69-3fbc-4821-b1aa-715eefb4103f.png)

